### PR TITLE
Add audio streaming support to host and sample cartridge

### DIFF
--- a/MicroBoy.Abstractions/Abstractions.cs
+++ b/MicroBoy.Abstractions/Abstractions.cs
@@ -26,4 +26,8 @@ public interface ICartridge
     void Init();
     void Update(Input input, double dt);
     void Render(Span<byte> frame);
+
+    int AudioSampleRate => 44100;
+    int AudioChannelCount => 2;
+    void MixAudio(Span<float> buffer) => buffer.Clear();
 }

--- a/MicroBoyHost/MicroBoyHost.csproj
+++ b/MicroBoyHost/MicroBoyHost.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\MicroBoy.Abstractions\MicroBoy.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add default audio capabilities to the cartridge abstraction so existing carts remain source-compatible
- integrate an NAudio-based streaming mixer in the WinForms host and feed it each frame after cartridge updates
- extend the sample cartridge with a simple melody synthesizer to demonstrate the new audio path

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7d69d0a4c832cb65c6d08153f1b00