### PR TITLE
Refactor sample cartridge into modular components

### DIFF
--- a/MicroBoyCart.Sample/Audio/WalkingTheme.cs
+++ b/MicroBoyCart.Sample/Audio/WalkingTheme.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace MicroBoyCart.Sample.Audio;
+
+public sealed class WalkingTheme
+{
+    private readonly double[] melody = { 220.0, 246.0, 262.0, 294.0, 330.0, 294.0, 262.0, 246.0 };
+
+    private double audioPhase;
+    private double melodyTimer;
+    private int melodyIndex;
+
+    public void Reset()
+    {
+        audioPhase = 0;
+        melodyTimer = 0;
+        melodyIndex = 0;
+    }
+
+    public void MixAudio(Span<float> buffer, bool isMoving, int sampleRate, int channelCount)
+    {
+        if (channelCount <= 0)
+        {
+            buffer.Clear();
+            return;
+        }
+
+        int samples = buffer.Length / channelCount;
+        if (samples <= 0)
+        {
+            buffer.Clear();
+            return;
+        }
+
+        double stepDuration = isMoving ? 0.18 : 0.32;
+        double vibratoSpeed = isMoving ? 8.0 : 5.0;
+        double vibratoDepth = isMoving ? 6.0 : 3.0;
+        const double twoPi = Math.PI * 2.0;
+
+        for (int i = 0; i < samples; i++)
+        {
+            melodyTimer += 1.0 / sampleRate;
+            if (melodyTimer >= stepDuration)
+            {
+                melodyTimer -= stepDuration;
+                melodyIndex = (melodyIndex + 1) % melody.Length;
+            }
+
+            double freq = melody[melodyIndex];
+            double vibrato = Math.Sin((melodyTimer + i / (double)sampleRate) * twoPi * vibratoSpeed) * vibratoDepth;
+            double phaseStep = twoPi * (freq + vibrato) / sampleRate;
+
+            audioPhase += phaseStep;
+            if (audioPhase >= twoPi)
+            {
+                audioPhase -= twoPi;
+            }
+
+            float sample = (float)(Math.Sin(audioPhase) * 0.18);
+            int baseIndex = i * channelCount;
+            for (int ch = 0; ch < channelCount; ch++)
+            {
+                buffer[baseIndex + ch] = sample;
+            }
+        }
+    }
+}

--- a/MicroBoyCart.Sample/Gameplay/PlayerController.cs
+++ b/MicroBoyCart.Sample/Gameplay/PlayerController.cs
@@ -1,0 +1,360 @@
+using MicroBoy;
+using System;
+using MicroBoyCart.Sample.Maps;
+using MicroBoyCart.Sample.Tiles;
+using MicroBoyCart.Sample;
+
+namespace MicroBoyCart.Sample.Gameplay;
+
+public sealed class PlayerController
+{
+    private const double DamageCooldownDuration = 1.0;
+
+    private readonly MapRepository mapRepository;
+    private readonly TileRules tileRules;
+
+    private MapDefinition currentMap;
+    private string currentMapId = string.Empty;
+
+    public PlayerController(MapRepository mapRepository, TileRules tileRules)
+    {
+        this.mapRepository = mapRepository;
+        this.tileRules = tileRules;
+        currentMap = mapRepository.GetDefaultMap();
+        currentMapId = mapRepository.DefaultMapId;
+    }
+
+    public PlayerState State { get; } = new();
+
+    public event Action? PlayerDefeated;
+
+    public MapDefinition CurrentMap => currentMap;
+    public string CurrentMapId => currentMapId;
+
+    public void StartNewGame()
+    {
+        SetCurrentMap(mapRepository.DefaultMapId);
+
+        State.MaxHealth = 6;
+        State.CurrentHealth = State.MaxHealth;
+        State.DamageCooldownTimer = 0;
+        State.HasSurfAbility = false;
+        State.TotalPlayTime = 0;
+        State.Direction = 0;
+        State.PendingWarp = null;
+        State.StepSpeedPx = Math.Max(1, State.StepSpeedPx);
+
+        State.SnapToTile(5, 10);
+    }
+
+    public void LoadFromSaveData(GameSaveData data)
+    {
+        var mapId = string.IsNullOrWhiteSpace(data.CurrentMapId) ? mapRepository.DefaultMapId : data.CurrentMapId;
+        if (!mapRepository.TryGetMap(mapId, out var map))
+        {
+            mapId = mapRepository.DefaultMapId;
+            map = mapRepository.GetDefaultMap();
+        }
+
+        currentMap = map;
+        currentMapId = mapId;
+
+        int tileX = Math.Clamp(data.PlayerTileX, 0, currentMap.Width - 1);
+        int tileY = Math.Clamp(data.PlayerTileY, 0, currentMap.Height - 1);
+        State.SnapToTile(tileX, tileY);
+
+        State.CurrentHealth = data.CurrentHealth;
+        State.MaxHealth = data.MaxHealth;
+        State.HasSurfAbility = data.HasSurfAbility;
+        State.TotalPlayTime = data.PlayTimeSeconds;
+        State.Direction = 0;
+        State.PendingWarp = null;
+        State.DamageCooldownTimer = 0;
+    }
+
+    public GameSaveData CreateSaveData()
+    {
+        return new GameSaveData
+        {
+            PlayerTileX = State.TileX,
+            PlayerTileY = State.TileY,
+            CurrentMapId = currentMapId,
+            CurrentHealth = State.CurrentHealth,
+            MaxHealth = State.MaxHealth,
+            HasSurfAbility = State.HasSurfAbility,
+            PlayTimeSeconds = State.TotalPlayTime,
+            SaveDate = DateTime.Now,
+            SaveVersion = 1
+        };
+    }
+
+    public void Update(Input input, double dt)
+    {
+        State.TotalPlayTime += dt;
+
+        if (State.DamageCooldownTimer > 0)
+        {
+            State.DamageCooldownTimer = Math.Max(0, State.DamageCooldownTimer - dt);
+        }
+
+        if (input.IsDown(Buttons.A))
+        {
+            State.HasSurfAbility = true;
+        }
+
+        if (State.IsMoving)
+        {
+            AdvanceTowardsTarget();
+
+            if (State.PixelX == State.TargetPixelX && State.PixelY == State.TargetPixelY)
+            {
+                State.IsMoving = false;
+                State.TileX = State.PixelX / Tileset.TileWidth;
+                State.TileY = State.PixelY / Tileset.TileHeight;
+
+                if (State.PendingWarp is { } warpPoint)
+                {
+                    State.PendingWarp = null;
+                    ExecuteWarp(warpPoint);
+                }
+
+                EvaluateHazardState();
+                return;
+            }
+
+            EvaluateHazardState();
+            return;
+        }
+
+        int nextTileX = State.TileX;
+        int nextTileY = State.TileY;
+
+        if (input.IsDown(Buttons.Left))
+        {
+            nextTileX = State.TileX - 1;
+            State.Direction = 1;
+        }
+        else if (input.IsDown(Buttons.Right))
+        {
+            nextTileX = State.TileX + 1;
+            State.Direction = 2;
+        }
+        else if (input.IsDown(Buttons.Up))
+        {
+            nextTileY = State.TileY - 1;
+            State.Direction = 3;
+        }
+        else if (input.IsDown(Buttons.Down))
+        {
+            nextTileY = State.TileY + 1;
+            State.Direction = 0;
+        }
+        else
+        {
+            EvaluateHazardState();
+            return;
+        }
+
+        if (IsWalkable(nextTileX, nextTileY, out var warp))
+        {
+            State.TileX = nextTileX;
+            State.TileY = nextTileY;
+            State.TargetPixelX = State.TileX * Tileset.TileWidth;
+            State.TargetPixelY = State.TileY * Tileset.TileHeight;
+            State.IsMoving = true;
+            State.PendingWarp = warp.IsValid ? warp : null;
+        }
+        else
+        {
+            State.PendingWarp = null;
+        }
+
+        EvaluateHazardState();
+    }
+
+    private void AdvanceTowardsTarget()
+    {
+        if (State.PixelX < State.TargetPixelX)
+        {
+            State.PixelX = Math.Min(State.TargetPixelX, State.PixelX + State.StepSpeedPx);
+        }
+        else if (State.PixelX > State.TargetPixelX)
+        {
+            State.PixelX = Math.Max(State.TargetPixelX, State.PixelX - State.StepSpeedPx);
+        }
+
+        if (State.PixelY < State.TargetPixelY)
+        {
+            State.PixelY = Math.Min(State.TargetPixelY, State.PixelY + State.StepSpeedPx);
+        }
+        else if (State.PixelY > State.TargetPixelY)
+        {
+            State.PixelY = Math.Max(State.TargetPixelY, State.PixelY - State.StepSpeedPx);
+        }
+    }
+
+    private bool IsWalkable(int tileX, int tileY, out WarpPoint warp)
+    {
+        warp = WarpPoint.None;
+
+        if (currentMap is null)
+        {
+            return false;
+        }
+
+        if (tileX < 0 || tileY < 0 || tileX >= currentMap.Width || tileY >= currentMap.Height)
+        {
+            return false;
+        }
+
+        byte overlayId = currentMap.GetOverlay(tileX, tileY);
+        if (overlayId != Tileset.TileNone)
+        {
+            var overlayInfo = tileRules.Get(overlayId);
+            switch (overlayInfo.Collision)
+            {
+                case TileCollisionType.Blocked:
+                    return false;
+                case TileCollisionType.Water:
+                    return State.HasSurfAbility;
+                case TileCollisionType.Warp:
+                    if (currentMap.TryGetWarp(tileX, tileY, out var foundWarp))
+                    {
+                        warp = foundWarp;
+                        return true;
+                    }
+                    return false;
+            }
+        }
+
+        byte baseId = currentMap.GetGround(tileX, tileY);
+        var baseInfo = tileRules.Get(baseId);
+        switch (baseInfo.Collision)
+        {
+            case TileCollisionType.Blocked:
+                return false;
+            case TileCollisionType.Water:
+                return State.HasSurfAbility;
+            case TileCollisionType.Warp:
+                if (currentMap.TryGetWarp(tileX, tileY, out var foundWarp))
+                {
+                    warp = foundWarp;
+                    return true;
+                }
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    private bool IsHazardTile(int tileX, int tileY)
+    {
+        byte overlayId = currentMap.GetOverlay(tileX, tileY);
+        if (overlayId != Tileset.TileNone)
+        {
+            if (overlayId == Tileset.TileTallGrassId)
+            {
+                return true;
+            }
+
+            var overlayInfo = tileRules.Get(overlayId);
+            if (overlayInfo.Collision == TileCollisionType.Water && !State.HasSurfAbility)
+            {
+                return true;
+            }
+        }
+
+        byte baseId = currentMap.GetGround(tileX, tileY);
+        if (baseId == Tileset.TileTallGrassId)
+        {
+            return true;
+        }
+
+        var baseInfo = tileRules.Get(baseId);
+        if (baseInfo.Collision == TileCollisionType.Water && !State.HasSurfAbility)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void EvaluateHazardState()
+    {
+        if (currentMap is null)
+        {
+            return;
+        }
+
+        if (State.CurrentHealth <= 0)
+        {
+            PlayerDefeated?.Invoke();
+            return;
+        }
+
+        if (State.PixelX < 0 || State.PixelY < 0)
+        {
+            return;
+        }
+
+        int tileX = State.PixelX / Tileset.TileWidth;
+        int tileY = State.PixelY / Tileset.TileHeight;
+
+        if ((uint)tileX >= (uint)currentMap.Width || (uint)tileY >= (uint)currentMap.Height)
+        {
+            return;
+        }
+
+        if (!IsHazardTile(tileX, tileY))
+        {
+            return;
+        }
+
+        if (State.DamageCooldownTimer > 0)
+        {
+            return;
+        }
+
+        State.CurrentHealth = Math.Max(0, State.CurrentHealth - 1);
+        State.DamageCooldownTimer = DamageCooldownDuration;
+
+        if (State.CurrentHealth <= 0)
+        {
+            PlayerDefeated?.Invoke();
+        }
+    }
+
+    private void ExecuteWarp(WarpPoint warp)
+    {
+        if (!warp.IsValid)
+        {
+            return;
+        }
+
+        if (!mapRepository.TryGetMap(warp.MapId, out var nextMap))
+        {
+            return;
+        }
+
+        currentMap = nextMap;
+        currentMapId = warp.MapId;
+
+        int destX = Math.Clamp(warp.TargetX, 0, currentMap.Width - 1);
+        int destY = Math.Clamp(warp.TargetY, 0, currentMap.Height - 1);
+
+        State.SnapToTile(destX, destY);
+    }
+
+    private void SetCurrentMap(string mapId)
+    {
+        if (!mapRepository.TryGetMap(mapId, out var map))
+        {
+            currentMap = mapRepository.GetDefaultMap();
+            currentMapId = mapRepository.DefaultMapId;
+            return;
+        }
+
+        currentMap = map;
+        currentMapId = mapId;
+    }
+}

--- a/MicroBoyCart.Sample/Gameplay/PlayerState.cs
+++ b/MicroBoyCart.Sample/Gameplay/PlayerState.cs
@@ -1,0 +1,34 @@
+using MicroBoyCart.Sample.Maps;
+using MicroBoyCart.Sample.Tiles;
+
+namespace MicroBoyCart.Sample.Gameplay;
+
+public class PlayerState
+{
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+    public int PixelX { get; set; }
+    public int PixelY { get; set; }
+    public int TargetPixelX { get; set; }
+    public int TargetPixelY { get; set; }
+    public bool IsMoving { get; set; }
+    public int StepSpeedPx { get; set; } = 2;
+    public int Direction { get; set; }
+    public int MaxHealth { get; set; }
+    public int CurrentHealth { get; set; }
+    public double DamageCooldownTimer { get; set; }
+    public bool HasSurfAbility { get; set; }
+    public WarpPoint? PendingWarp { get; set; }
+    public double TotalPlayTime { get; set; }
+
+    public void SnapToTile(int tileX, int tileY)
+    {
+        TileX = tileX;
+        TileY = tileY;
+        PixelX = tileX * Tileset.TileWidth;
+        PixelY = tileY * Tileset.TileHeight;
+        TargetPixelX = PixelX;
+        TargetPixelY = PixelY;
+        IsMoving = false;
+    }
+}

--- a/MicroBoyCart.Sample/Maps/MapRepository.cs
+++ b/MicroBoyCart.Sample/Maps/MapRepository.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using MicroBoyCart.Sample.Tiles;
+
+namespace MicroBoyCart.Sample.Maps;
+
+public sealed class MapRepository
+{
+    private readonly Dictionary<string, MapDefinition> maps;
+
+    public MapRepository()
+    {
+        maps = BuildMaps();
+    }
+
+    public string DefaultMapId => "overworld";
+
+    public MapDefinition GetDefaultMap() => maps[DefaultMapId];
+
+    public bool TryGetMap(string mapId, out MapDefinition map) => maps.TryGetValue(mapId, out map);
+
+    private Dictionary<string, MapDefinition> BuildMaps()
+    {
+        var baseLegend = new Dictionary<char, byte>
+        {
+            ['G'] = Tileset.TileGrassId,
+            ['P'] = Tileset.TilePathId,
+            ['H'] = Tileset.TileTallGrassId,
+            ['W'] = Tileset.TileWaterId,
+            ['F'] = Tileset.TileFloorId,
+        };
+
+        var overlayLegend = new Dictionary<char, byte>
+        {
+            ['T'] = Tileset.TileTreeId,
+            ['t'] = Tileset.TileTallGrassId,
+            ['D'] = Tileset.TileDoorId,
+            ['#'] = Tileset.TileWallId,
+            ['r'] = Tileset.TileRugId,
+        };
+
+        const string OverworldGroundData = """
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGPPPPPPPPPPPPPPPPPPPPPPPPPPPPGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGHHHHHHHHHGGGGGGGGGGGGGGGGGGG
+GGGGHHHHHHHHHGGGGGGGGGGGGGGGGGGG
+GGGGHHHHHHHHHGGGGGGGGGGGGGGGGGGG
+GGGGHHHHHHHHHGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGPPPPPPPPPPPPPPPPGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGWWWWWWWWGGGG
+GGGGGGGGGGGGGGGGGGGGWWWWWWWWGGGG
+GGGGGGGGGGGGGGGGGGGGWWWWWWWWGGGG
+GGGGGGGGGGGGGGGGGGGGWWWWWWWWGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+""";
+
+        const string OverworldOverlayData = """
+TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T...............T..............T
+T...............T..............T
+T...............T..............T
+T...............T..............T
+T...............T..............T
+T...............T.......D......T
+T...............T..............T
+T...............T..............T
+T...............T..............T
+T...ttttttttt..................T
+T...ttttttttt..................T
+T...ttttttttt..................T
+T...ttttttttt..................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+T..............................T
+TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+""";
+
+        const string HouseGroundData = """
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+FFFFFFFFFFFFFFFF
+""";
+
+        const string HouseOverlayData = """
+################
+#..............#
+#..............#
+#..............#
+#...rrrrrrrr...#
+#...rrrrrrrr...#
+#...rrrrrrrr...#
+#...rrrrrrrr...#
+#..............#
+#..............#
+#..............#
+#..............#
+#..............#
+#..............#
+#..............#
+########D#######
+""";
+
+        return new Dictionary<string, MapDefinition>
+        {
+            ["overworld"] = new MapDefinition(
+                ParseLayer(OverworldGroundData, baseLegend),
+                ParseLayer(OverworldOverlayData, overlayLegend, Tileset.TileNone),
+                new Dictionary<(int x, int y), WarpPoint>
+                {
+                    [(24, 10)] = new WarpPoint("house", 8, 14),
+                }),
+            ["house"] = new MapDefinition(
+                ParseLayer(HouseGroundData, baseLegend),
+                ParseLayer(HouseOverlayData, overlayLegend, Tileset.TileNone),
+                new Dictionary<(int x, int y), WarpPoint>
+                {
+                    [(8, 15)] = new WarpPoint("overworld", 24, 11),
+                }),
+        };
+    }
+
+    private static byte[,] ParseLayer(string data, Dictionary<char, byte> legend, byte? defaultValue = null)
+    {
+        var rows = data.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (rows.Length == 0)
+        {
+            throw new InvalidOperationException("Keine Layerdaten vorhanden.");
+        }
+
+        int width = rows[0].TrimEnd('\r').Length;
+        var result = new byte[rows.Length, width];
+
+        for (int y = 0; y < rows.Length; y++)
+        {
+            var row = rows[y].TrimEnd('\r');
+            if (row.Length != width)
+            {
+                throw new InvalidOperationException("Uneinheitliche Zeilenlänge in den Map-Daten.");
+            }
+
+            for (int x = 0; x < width; x++)
+            {
+                char ch = row[x];
+                if (legend.TryGetValue(ch, out var id))
+                {
+                    result[y, x] = id;
+                }
+                else if (defaultValue.HasValue)
+                {
+                    result[y, x] = defaultValue.Value;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unbekanntes Tile-Zeichen '{ch}'.");
+                }
+            }
+        }
+
+        return result;
+    }
+}
+
+public sealed class MapDefinition
+{
+    private readonly byte[,] ground;
+    private readonly byte[,] overlay;
+    private readonly Dictionary<(int x, int y), WarpPoint> warps;
+
+    public MapDefinition(byte[,] ground, byte[,] overlay, Dictionary<(int x, int y), WarpPoint> warps)
+    {
+        if (ground.GetLength(0) != overlay.GetLength(0) || ground.GetLength(1) != overlay.GetLength(1))
+        {
+            throw new ArgumentException("Layer-Größen stimmen nicht überein.", nameof(overlay));
+        }
+
+        this.ground = ground;
+        this.overlay = overlay;
+        this.warps = warps;
+    }
+
+    public int Width => ground.GetLength(1);
+    public int Height => ground.GetLength(0);
+
+    public byte GetGround(int x, int y) => ground[y, x];
+    public byte GetOverlay(int x, int y) => overlay[y, x];
+
+    public bool TryGetWarp(int x, int y, out WarpPoint warp)
+    {
+        if (warps.TryGetValue((x, y), out warp))
+        {
+            return true;
+        }
+
+        warp = WarpPoint.None;
+        return false;
+    }
+}
+
+public readonly record struct WarpPoint(string MapId, int TargetX, int TargetY)
+{
+    public bool IsValid => !string.IsNullOrEmpty(MapId);
+    public static WarpPoint None => new(string.Empty, 0, 0);
+}

--- a/MicroBoyCart.Sample/Maps/TileRules.cs
+++ b/MicroBoyCart.Sample/Maps/TileRules.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using MicroBoyCart.Sample.Tiles;
+
+namespace MicroBoyCart.Sample.Maps;
+
+public enum TileCollisionType
+{
+    Walkable,
+    Blocked,
+    Water,
+    Warp,
+}
+
+public readonly record struct TileInfo(TileCollisionType Collision)
+{
+    public static readonly TileInfo Walkable = new(TileCollisionType.Walkable);
+}
+
+public sealed class TileRules
+{
+    private readonly Dictionary<byte, TileInfo> rules;
+
+    public TileRules()
+    {
+        rules = new Dictionary<byte, TileInfo>
+        {
+            [Tileset.TileGrassId] = TileInfo.Walkable,
+            [Tileset.TilePathId] = TileInfo.Walkable,
+            [Tileset.TileTreeId] = new TileInfo(TileCollisionType.Blocked),
+            [Tileset.TileTallGrassId] = TileInfo.Walkable,
+            [Tileset.TileWaterId] = new TileInfo(TileCollisionType.Water),
+            [Tileset.TileDoorId] = new TileInfo(TileCollisionType.Warp),
+            [Tileset.TileFloorId] = TileInfo.Walkable,
+            [Tileset.TileWallId] = new TileInfo(TileCollisionType.Blocked),
+            [Tileset.TileRugId] = TileInfo.Walkable,
+        };
+    }
+
+    public TileInfo Get(byte id)
+    {
+        if (rules.TryGetValue(id, out var info))
+        {
+            return info;
+        }
+
+        return TileInfo.Walkable;
+    }
+}

--- a/MicroBoyCart.Sample/Rendering/HudRenderer.cs
+++ b/MicroBoyCart.Sample/Rendering/HudRenderer.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using MicroBoy;
+using MicroBoyCart.Sample.Gameplay;
+using MicroBoyCart.Sample.Tiles;
+
+namespace MicroBoyCart.Sample.Rendering;
+
+public sealed class HudRenderer
+{
+    private readonly Dictionary<char, byte[,]> glyphs = new()
+    {
+        ['G'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 } },
+        ['A'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['M'] = new byte[,] { { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['E'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
+        ['S'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 1 }, { 0, 0, 1 }, { 1, 1, 1 } },
+        ['V'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
+        ['D'] = new byte[,] { { 1, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 0 } },
+        ['L'] = new byte[,] { { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
+        ['O'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
+        ['F'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 0, 0 } },
+        ['I'] = new byte[,] { { 1, 1, 1 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 }, { 1, 1, 1 } },
+        ['!'] = new byte[,] { { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 0, 0, 0 }, { 1, 0, 0 } },
+        [' '] = new byte[,] { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } },
+    };
+
+    public void Render(Span<byte> frame, PlayerState playerState, bool showSaveMessage, string? message)
+    {
+        DrawHealthBar(frame, playerState.MaxHealth, playerState.CurrentHealth);
+
+        if (showSaveMessage && !string.IsNullOrWhiteSpace(message))
+        {
+            DrawSaveMessage(frame, message);
+        }
+    }
+
+    private static void DrawHealthBar(Span<byte> framebuffer, int maxHealth, int currentHealth)
+    {
+        const int startX = 4;
+        const int startY = 4;
+        const int spacing = 2;
+        const int heartWidth = 6;
+
+        for (int i = 0; i < maxHealth; i++)
+        {
+            int drawX = startX + i * (heartWidth + spacing);
+            DrawHeartSprite(framebuffer, drawX, startY, i < currentHealth);
+        }
+    }
+
+    private static void DrawHeartSprite(Span<byte> framebuffer, int drawX, int drawY, bool filled)
+    {
+        var sprite = filled ? Tileset.HeartFull : Tileset.HeartEmpty;
+        int height = sprite.GetLength(0);
+        int width = sprite.GetLength(1);
+
+        for (int y = 0; y < height; y++)
+        {
+            int rowY = drawY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < width; x++)
+            {
+                int rowX = drawX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                byte color = sprite[y, x];
+                if (color != 0)
+                {
+                    framebuffer[framebufferRow + rowX] = color;
+                }
+            }
+        }
+    }
+
+    private void DrawSaveMessage(Span<byte> frame, string message)
+    {
+        const int boxWidth = 80;
+        const int boxHeight = 16;
+        const int boxX = (MicroBoySpec.W - boxWidth) / 2;
+        const int boxY = 20;
+
+        for (int y = 0; y < boxHeight; y++)
+        {
+            int rowY = boxY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < boxWidth; x++)
+            {
+                int rowX = boxX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                frame[framebufferRow + rowX] = (y == 0 || y == boxHeight - 1 || x == 0 || x == boxWidth - 1)
+                    ? Tileset.ColorPathDark
+                    : Tileset.ColorPathLight;
+            }
+        }
+
+        DrawText(frame, boxX + 8, boxY + 5, message);
+    }
+
+    private void DrawText(Span<byte> frame, int startX, int startY, string message)
+    {
+        int offset = 0;
+        foreach (char character in message)
+        {
+            DrawChar(frame, startX + offset, startY, character);
+            offset += 4;
+        }
+    }
+
+    private void DrawChar(Span<byte> frame, int startX, int startY, char character)
+    {
+        if (!glyphs.TryGetValue(character, out var pattern))
+        {
+            return;
+        }
+
+        for (int y = 0; y < pattern.GetLength(0); y++)
+        {
+            int rowY = startY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < pattern.GetLength(1); x++)
+            {
+                if (pattern[y, x] == 0)
+                {
+                    continue;
+                }
+
+                int rowX = startX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                frame[framebufferRow + rowX] = Tileset.ColorPathDark;
+            }
+        }
+    }
+}

--- a/MicroBoyCart.Sample/Rendering/TileRenderer.cs
+++ b/MicroBoyCart.Sample/Rendering/TileRenderer.cs
@@ -1,0 +1,127 @@
+using System;
+using MicroBoy;
+using MicroBoyCart.Sample.Gameplay;
+using MicroBoyCart.Sample.Maps;
+using MicroBoyCart.Sample.Tiles;
+
+namespace MicroBoyCart.Sample.Rendering;
+
+public sealed class TileRenderer
+{
+    public void Render(Span<byte> frame, MapDefinition map, PlayerState playerState)
+    {
+        if (map is null)
+        {
+            return;
+        }
+
+        int mapPixelWidth = map.Width * Tileset.TileWidth;
+        int mapPixelHeight = map.Height * Tileset.TileHeight;
+
+        int camX = playerState.PixelX - MicroBoySpec.W / 2;
+        int camY = playerState.PixelY - MicroBoySpec.H / 2;
+
+        camX = Math.Clamp(camX, 0, Math.Max(0, mapPixelWidth - MicroBoySpec.W));
+        camY = Math.Clamp(camY, 0, Math.Max(0, mapPixelHeight - MicroBoySpec.H));
+
+        frame.Fill(0);
+
+        int firstTileX = camX / Tileset.TileWidth;
+        int firstTileY = camY / Tileset.TileHeight;
+        int offsetX = -(camX % Tileset.TileWidth);
+        int offsetY = -(camY % Tileset.TileHeight);
+
+        for (int tileY = 0, mapY = firstTileY; mapY < map.Height && tileY < MicroBoySpec.H; mapY++, tileY += Tileset.TileHeight)
+        {
+            int drawY = offsetY + tileY;
+            if (drawY >= MicroBoySpec.H)
+            {
+                break;
+            }
+
+            for (int tileX = 0, mapX = firstTileX; mapX < map.Width && tileX < MicroBoySpec.W; mapX++, tileX += Tileset.TileWidth)
+            {
+                int drawX = offsetX + tileX;
+                if (drawX >= MicroBoySpec.W)
+                {
+                    break;
+                }
+
+                byte baseId = map.GetGround(mapX, mapY);
+                byte overlayId = map.GetOverlay(mapX, mapY);
+                BlitTile(frame, drawX, drawY, baseId, overlayId);
+            }
+        }
+
+        DrawPlayer(frame, playerState.PixelX - camX, playerState.PixelY - camY, playerState.PixelX, playerState.PixelY);
+    }
+
+    private static void BlitTile(Span<byte> framebuffer, int destX, int destY, byte baseId, byte overlayId)
+    {
+        DrawTileLayer(framebuffer, destX, destY, baseId, transparent: false);
+        if (overlayId != Tileset.TileNone)
+        {
+            DrawTileLayer(framebuffer, destX, destY, overlayId, transparent: true);
+        }
+    }
+
+    private static void DrawTileLayer(Span<byte> framebuffer, int destX, int destY, byte tileId, bool transparent)
+    {
+        var tile = Tileset.GetTileSprite(tileId);
+        for (int y = 0; y < Tileset.TileHeight; y++)
+        {
+            int rowY = destY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < Tileset.TileWidth; x++)
+            {
+                int rowX = destX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                byte color = tile[y, x];
+                if (transparent && color == 0)
+                {
+                    continue;
+                }
+
+                framebuffer[framebufferRow + rowX] = color;
+            }
+        }
+    }
+
+    private static void DrawPlayer(Span<byte> framebuffer, int drawX, int drawY, int worldX, int worldY)
+    {
+        var sprite = Tileset.GetPlayerFrame(worldX, worldY);
+        for (int y = 0; y < Tileset.TileHeight; y++)
+        {
+            int rowY = drawY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < Tileset.TileWidth; x++)
+            {
+                int rowX = drawX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                byte color = sprite[y, x];
+                if (color != 0)
+                {
+                    framebuffer[framebufferRow + rowX] = color;
+                }
+            }
+        }
+    }
+}

--- a/MicroBoyCart.Sample/Tiles/Tileset.cs
+++ b/MicroBoyCart.Sample/Tiles/Tileset.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+
+namespace MicroBoyCart.Sample.Tiles;
+
+public static class Tileset
+{
+    public const int TileWidth = 8;
+    public const int TileHeight = 8;
+
+    public const byte TileGrassId = 0;
+    public const byte TilePathId = 1;
+    public const byte TileTreeId = 2;
+    public const byte TileTallGrassId = 3;
+    public const byte TileWaterId = 4;
+    public const byte TileDoorId = 5;
+    public const byte TileFloorId = 6;
+    public const byte TileWallId = 7;
+    public const byte TileRugId = 8;
+    public const byte TileNone = byte.MaxValue;
+
+    public const byte ColorGrassDark = 0;
+    public const byte ColorGrassMid = 1;
+    public const byte ColorGrassLight = 2;
+    public const byte ColorGrassHighlight = 3;
+    public const byte ColorPathLight = 4;
+    public const byte ColorPathDark = 5;
+    public const byte ColorWaterDeep = 6;
+    public const byte ColorWaterLight = 7;
+    public const byte ColorStone = 8;
+    public const byte ColorRug = 9;
+
+    public static readonly byte[,] GrassTile =
+    {
+        {ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid},
+        {ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight},
+        {ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassHighlight},
+        {ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight},
+        {ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassMid},
+        {ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight},
+        {ColorGrassDark, ColorGrassMid, ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassDark, ColorGrassMid, ColorGrassHighlight},
+        {ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight, ColorGrassMid, ColorGrassLight},
+    };
+
+    public static readonly byte[,] PathTile =
+    {
+        {ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark},
+    };
+
+    public static readonly byte[,] TreeTile =
+    {
+        {ColorGrassDark, ColorGrassDark, ColorGrassDark, ColorGrassDark, ColorGrassDark, ColorGrassDark, ColorGrassDark, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassMid, ColorGrassMid, ColorGrassMid, ColorGrassHighlight, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassLight, ColorGrassLight, ColorGrassMid, ColorGrassHighlight, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassLight, ColorGrassLight, ColorGrassMid, ColorGrassHighlight, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassMid, ColorGrassMid, ColorGrassMid, ColorGrassMid, ColorGrassHighlight, ColorGrassDark},
+        {ColorGrassDark, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassHighlight, ColorGrassDark},
+        {ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark},
+    };
+
+    public static readonly byte[,] TallGrassTile =
+    {
+        {ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight},
+        {ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight},
+        {ColorGrassLight, ColorGrassMid, ColorGrassHighlight, ColorGrassMid, ColorGrassHighlight, ColorGrassMid, ColorGrassLight, ColorGrassHighlight},
+        {ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight},
+        {ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight},
+        {ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight},
+        {ColorGrassLight, ColorGrassMid, ColorGrassHighlight, ColorGrassMid, ColorGrassHighlight, ColorGrassMid, ColorGrassLight, ColorGrassHighlight},
+        {ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight, ColorGrassHighlight, ColorGrassLight},
+    };
+
+    public static readonly byte[,] WaterTile =
+    {
+        {ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterDeep, ColorWaterLight, ColorWaterLight, ColorWaterDeep},
+        {ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep, ColorWaterDeep},
+    };
+
+    public static readonly byte[,] DoorTile =
+    {
+        {ColorGrassDark, ColorGrassDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorGrassDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, ColorGrassDark},
+        {ColorGrassDark, ColorGrassDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorGrassDark, ColorGrassDark},
+    };
+
+    public static readonly byte[,] FloorTile =
+    {
+        {ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight},
+        {ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone},
+        {ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight},
+        {ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone},
+        {ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight},
+        {ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone},
+        {ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight},
+        {ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone, ColorPathLight, ColorStone},
+    };
+
+    public static readonly byte[,] WallTile =
+    {
+        {ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone},
+        {ColorStone, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorStone},
+        {ColorStone, ColorPathDark, ColorStone, ColorStone, ColorStone, ColorStone, ColorPathDark, ColorStone},
+        {ColorStone, ColorPathDark, ColorStone, ColorStone, ColorStone, ColorStone, ColorPathDark, ColorStone},
+        {ColorStone, ColorPathDark, ColorStone, ColorStone, ColorStone, ColorStone, ColorPathDark, ColorStone},
+        {ColorStone, ColorPathDark, ColorStone, ColorStone, ColorStone, ColorStone, ColorPathDark, ColorStone},
+        {ColorStone, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, ColorStone},
+        {ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone, ColorStone},
+    };
+
+    public static readonly byte[,] RugTile =
+    {
+        {ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark},
+        {ColorRug, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorRug},
+        {ColorRug, ColorPathLight, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathLight, ColorRug},
+        {ColorRug, ColorPathLight, ColorRug, ColorPathLight, ColorPathLight, ColorRug, ColorPathLight, ColorRug},
+        {ColorRug, ColorPathLight, ColorRug, ColorPathLight, ColorPathLight, ColorRug, ColorPathLight, ColorRug},
+        {ColorRug, ColorPathLight, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathLight, ColorRug},
+        {ColorRug, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorRug},
+        {ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark},
+    };
+
+    public static readonly byte[,] HeartFull =
+    {
+        {0, ColorRug, ColorRug, ColorRug, ColorRug, 0},
+        {ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug},
+        {ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug},
+        {0, ColorRug, ColorRug, ColorRug, ColorRug, 0},
+        {0, 0, ColorRug, ColorRug, 0, 0},
+    };
+
+    public static readonly byte[,] HeartEmpty =
+    {
+        {0, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, 0},
+        {ColorPathLight, 0, 0, 0, 0, ColorPathLight},
+        {ColorPathLight, 0, 0, 0, 0, ColorPathLight},
+        {0, ColorPathLight, 0, 0, ColorPathLight, 0},
+        {0, 0, ColorPathLight, ColorPathLight, 0, 0},
+    };
+
+    public static readonly byte[,] PlayerFrame0 =
+    {
+        {0, 0, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, 0, 0},
+        {0, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, 0},
+        {ColorPathDark, ColorPathLight, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark},
+        {0, ColorPathDark, ColorRug, ColorPathDark, ColorPathDark, ColorRug, ColorPathDark, 0},
+        {0, ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark, 0},
+        {0, ColorPathDark, ColorStone, ColorStone, ColorStone, ColorStone, ColorPathDark, 0},
+        {0, 0, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, 0, 0},
+    };
+
+    public static readonly byte[,] PlayerFrame1 =
+    {
+        {0, 0, ColorPathDark, ColorPathDark, ColorPathDark, ColorPathDark, 0, 0},
+        {0, ColorPathDark, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathLight, ColorPathDark, 0},
+        {ColorPathDark, ColorPathLight, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathLight, ColorPathDark},
+        {ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark},
+        {0, ColorPathDark, ColorRug, ColorPathDark, ColorPathDark, ColorRug, ColorPathDark, 0},
+        {0, ColorPathDark, ColorRug, ColorRug, ColorRug, ColorRug, ColorPathDark, 0},
+        {0, 0, ColorPathDark, ColorStone, ColorStone, ColorPathDark, 0, 0},
+        {0, ColorPathDark, 0, 0, 0, 0, ColorPathDark, 0},
+    };
+
+    private static readonly Dictionary<byte, byte[,]> TileLookup = new()
+    {
+        [TileGrassId] = GrassTile,
+        [TilePathId] = PathTile,
+        [TileTreeId] = TreeTile,
+        [TileTallGrassId] = TallGrassTile,
+        [TileWaterId] = WaterTile,
+        [TileDoorId] = DoorTile,
+        [TileFloorId] = FloorTile,
+        [TileWallId] = WallTile,
+        [TileRugId] = RugTile,
+    };
+
+    public static byte[,] GetTileSprite(byte id) => TileLookup.TryGetValue(id, out var tile) ? tile : GrassTile;
+
+    public static byte[,] GetPlayerFrame(int pixelX, int pixelY)
+        => ((pixelX + pixelY) / TileWidth % 2 == 0) ? PlayerFrame0 : PlayerFrame1;
+}


### PR DESCRIPTION
## Summary
- extract gameplay logic into dedicated player controller/state classes
- move rendering, HUD, tileset, map, and audio responsibilities into focused components
- simplify the cartridge entry points to orchestrate the new subsystems

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd3b7745a4832cb6dda8298b630e28