### PR TITLE
Add pause menu state and rendering

### DIFF
--- a/MicroBoyCart.Sample/Rendering/HudRenderer.cs
+++ b/MicroBoyCart.Sample/Rendering/HudRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using MicroBoy;
 using MicroBoyCart.Sample.Gameplay;
 using MicroBoyCart.Sample.Tiles;
@@ -8,22 +7,7 @@ namespace MicroBoyCart.Sample.Rendering;
 
 public sealed class HudRenderer
 {
-    private readonly Dictionary<char, byte[,]> glyphs = new()
-    {
-        ['G'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 } },
-        ['A'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
-        ['M'] = new byte[,] { { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
-        ['E'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
-        ['S'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 1 }, { 0, 0, 1 }, { 1, 1, 1 } },
-        ['V'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
-        ['D'] = new byte[,] { { 1, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 0 } },
-        ['L'] = new byte[,] { { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
-        ['O'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
-        ['F'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 0, 0 } },
-        ['I'] = new byte[,] { { 1, 1, 1 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 }, { 1, 1, 1 } },
-        ['!'] = new byte[,] { { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 0, 0, 0 }, { 1, 0, 0 } },
-        [' '] = new byte[,] { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } },
-    };
+    private readonly TextRenderer textRenderer = new();
 
     public void Render(Span<byte> frame, PlayerState playerState, bool showSaveMessage, string? message)
     {
@@ -111,50 +95,6 @@ public sealed class HudRenderer
             }
         }
 
-        DrawText(frame, boxX + 8, boxY + 5, message);
-    }
-
-    private void DrawText(Span<byte> frame, int startX, int startY, string message)
-    {
-        int offset = 0;
-        foreach (char character in message)
-        {
-            DrawChar(frame, startX + offset, startY, character);
-            offset += 4;
-        }
-    }
-
-    private void DrawChar(Span<byte> frame, int startX, int startY, char character)
-    {
-        if (!glyphs.TryGetValue(character, out var pattern))
-        {
-            return;
-        }
-
-        for (int y = 0; y < pattern.GetLength(0); y++)
-        {
-            int rowY = startY + y;
-            if ((uint)rowY >= MicroBoySpec.H)
-            {
-                continue;
-            }
-
-            int framebufferRow = rowY * MicroBoySpec.W;
-            for (int x = 0; x < pattern.GetLength(1); x++)
-            {
-                if (pattern[y, x] == 0)
-                {
-                    continue;
-                }
-
-                int rowX = startX + x;
-                if ((uint)rowX >= MicroBoySpec.W)
-                {
-                    continue;
-                }
-
-                frame[framebufferRow + rowX] = Tileset.ColorPathDark;
-            }
-        }
+        textRenderer.DrawText(frame, boxX + 8, boxY + 5, message, Tileset.ColorPathDark);
     }
 }

--- a/MicroBoyCart.Sample/Rendering/PauseMenuRenderer.cs
+++ b/MicroBoyCart.Sample/Rendering/PauseMenuRenderer.cs
@@ -1,0 +1,101 @@
+using MicroBoy;
+using MicroBoyCart.Sample.Tiles;
+using MicroBoyCart.Sample.UI;
+
+namespace MicroBoyCart.Sample.Rendering;
+
+public sealed class PauseMenuRenderer
+{
+    private readonly TextRenderer textRenderer = new();
+
+    public void Render(Span<byte> frame, PauseMenuState pauseMenuState)
+    {
+        if (!pauseMenuState.IsOpen)
+        {
+            return;
+        }
+
+        const int panelWidth = 120;
+        const int panelHeight = 74;
+        int originX = (MicroBoySpec.W - panelWidth) / 2;
+        int originY = (MicroBoySpec.H - panelHeight) / 2;
+
+        DrawPanel(frame, originX, originY, panelWidth, panelHeight);
+
+        int titleX = originX + 12;
+        int titleY = originY + 8;
+        textRenderer.DrawText(frame, titleX, titleY, "PAUSE MENU", Tileset.ColorPathDark);
+
+        int entriesStartY = originY + 24;
+        int entriesStartX = originX + 12;
+        int entrySpacing = 16;
+
+        for (int i = 0; i < pauseMenuState.Entries.Count; i++)
+        {
+            var entry = pauseMenuState.Entries[i];
+            int entryY = entriesStartY + i * entrySpacing;
+            bool isSelected = i == pauseMenuState.SelectedIndex;
+
+            if (isSelected)
+            {
+                DrawHighlight(frame, originX + 8, entryY - 2, panelWidth - 16, 12);
+            }
+
+            textRenderer.DrawText(frame, entriesStartX, entryY, entry.Title, Tileset.ColorPathDark);
+
+            if (!string.IsNullOrWhiteSpace(entry.Subtext))
+            {
+                textRenderer.DrawText(frame, entriesStartX + 4, entryY + 6, entry.Subtext, Tileset.ColorGrassHighlight);
+            }
+        }
+    }
+
+    private static void DrawPanel(Span<byte> frame, int x, int y, int width, int height)
+    {
+        for (int offsetY = 0; offsetY < height; offsetY++)
+        {
+            int rowY = y + offsetY;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int offsetX = 0; offsetX < width; offsetX++)
+            {
+                int rowX = x + offsetX;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                bool isBorder = offsetY == 0 || offsetY == height - 1 || offsetX == 0 || offsetX == width - 1;
+                frame[framebufferRow + rowX] = isBorder ? Tileset.ColorPathDark : Tileset.ColorPathLight;
+            }
+        }
+    }
+
+    private static void DrawHighlight(Span<byte> frame, int x, int y, int width, int height)
+    {
+        for (int offsetY = 0; offsetY < height; offsetY++)
+        {
+            int rowY = y + offsetY;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int offsetX = 0; offsetX < width; offsetX++)
+            {
+                int rowX = x + offsetX;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                frame[framebufferRow + rowX] = Tileset.ColorRug;
+            }
+        }
+    }
+}

--- a/MicroBoyCart.Sample/Rendering/TextRenderer.cs
+++ b/MicroBoyCart.Sample/Rendering/TextRenderer.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using MicroBoy;
+
+namespace MicroBoyCart.Sample.Rendering;
+
+public sealed class TextRenderer
+{
+    private readonly Dictionary<char, byte[,]> glyphs = new()
+    {
+        ['A'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['B'] = new byte[,] { { 1, 1, 0 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 0, 1 }, { 1, 1, 0 } },
+        ['C'] = new byte[,] { { 0, 1, 1 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 0, 1, 1 } },
+        ['D'] = new byte[,] { { 1, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 0 } },
+        ['E'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
+        ['F'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 0 }, { 1, 0, 0 } },
+        ['G'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 } },
+        ['H'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['I'] = new byte[,] { { 1, 1, 1 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 }, { 1, 1, 1 } },
+        ['J'] = new byte[,] { { 0, 0, 1 }, { 0, 0, 1 }, { 0, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
+        ['K'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['L'] = new byte[,] { { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
+        ['M'] = new byte[,] { { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['N'] = new byte[,] { { 1, 0, 1 }, { 1, 1, 1 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['O'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
+        ['P'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 0 }, { 1, 0, 0 } },
+        ['Q'] = new byte[,] { { 0, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 1 }, { 0, 0, 1 } },
+        ['R'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 1, 0 }, { 1, 0, 1 } },
+        ['S'] = new byte[,] { { 1, 1, 1 }, { 1, 0, 0 }, { 1, 1, 1 }, { 0, 0, 1 }, { 1, 1, 1 } },
+        ['T'] = new byte[,] { { 1, 1, 1 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 } },
+        ['U'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 } },
+        ['V'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 } },
+        ['W'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 1, 0, 1 }, { 1, 1, 1 }, { 1, 0, 1 } },
+        ['X'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 }, { 1, 0, 1 }, { 1, 0, 1 } },
+        ['Y'] = new byte[,] { { 1, 0, 1 }, { 1, 0, 1 }, { 0, 1, 0 }, { 0, 1, 0 }, { 0, 1, 0 } },
+        ['Z'] = new byte[,] { { 1, 1, 1 }, { 0, 0, 1 }, { 0, 1, 0 }, { 1, 0, 0 }, { 1, 1, 1 } },
+        ['!'] = new byte[,] { { 1 }, { 1 }, { 1 }, { 0 }, { 1 } },
+        [' '] = new byte[,] { { 0 }, { 0 }, { 0 }, { 0 }, { 0 } },
+    };
+
+    public void DrawText(Span<byte> frame, int startX, int startY, string? text, byte color)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        int offset = 0;
+        foreach (char character in text)
+        {
+            DrawChar(frame, startX + offset, startY, character, color);
+            offset += 4;
+        }
+    }
+
+    public int MeasureWidth(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        return text.Length * 4;
+    }
+
+    private void DrawChar(Span<byte> frame, int startX, int startY, char character, byte color)
+    {
+        if (!glyphs.TryGetValue(character, out var pattern))
+        {
+            return;
+        }
+
+        int height = pattern.GetLength(0);
+        int width = pattern.GetLength(1);
+
+        for (int y = 0; y < height; y++)
+        {
+            int rowY = startY + y;
+            if ((uint)rowY >= MicroBoySpec.H)
+            {
+                continue;
+            }
+
+            int framebufferRow = rowY * MicroBoySpec.W;
+            for (int x = 0; x < width; x++)
+            {
+                if (pattern[y, x] == 0)
+                {
+                    continue;
+                }
+
+                int rowX = startX + x;
+                if ((uint)rowX >= MicroBoySpec.W)
+                {
+                    continue;
+                }
+
+                frame[framebufferRow + rowX] = color;
+            }
+        }
+    }
+}

--- a/MicroBoyCart.Sample/UI/PauseMenuState.cs
+++ b/MicroBoyCart.Sample/UI/PauseMenuState.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace MicroBoyCart.Sample.UI;
+
+public sealed class PauseMenuState
+{
+    private const string SaveEntryId = "save";
+    private const string SettingsEntryId = "settings";
+    private const string ResumeEntryId = "resume";
+
+    private readonly List<MenuEntry> entries = new()
+    {
+        new MenuEntry(SaveEntryId, "SAVE GAME", "WRITE PROGRESS"),
+        new MenuEntry(SettingsEntryId, "SETTINGS", "COMING SOON"),
+        new MenuEntry(ResumeEntryId, "RESUME", "RETURN TO PLAY"),
+    };
+
+    public bool IsOpen { get; private set; }
+    public int SelectedIndex { get; private set; }
+    public IReadOnlyList<MenuEntry> Entries => entries;
+    public MenuEntry SelectedEntry => entries[SelectedIndex];
+
+    public void Open()
+    {
+        if (IsOpen)
+        {
+            return;
+        }
+
+        IsOpen = true;
+        SelectedIndex = 0;
+    }
+
+    public void Close()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        IsOpen = false;
+        SelectedIndex = 0;
+    }
+
+    public void MoveNext()
+    {
+        if (!IsOpen || entries.Count == 0)
+        {
+            return;
+        }
+
+        SelectedIndex = (SelectedIndex + 1) % entries.Count;
+    }
+
+    public void MovePrevious()
+    {
+        if (!IsOpen || entries.Count == 0)
+        {
+            return;
+        }
+
+        SelectedIndex = (SelectedIndex - 1 + entries.Count) % entries.Count;
+    }
+
+    public bool IsSaveSelected() => SelectedEntry.Id == SaveEntryId;
+    public bool IsSettingsSelected() => SelectedEntry.Id == SettingsEntryId;
+    public bool IsResumeSelected() => SelectedEntry.Id == ResumeEntryId;
+
+    public readonly record struct MenuEntry(string Id, string Title, string? Subtext);
+}


### PR DESCRIPTION
## Summary
- add a pause menu state with navigation helpers and descriptive menu entries
- render the pause menu overlay on top of the HUD using a shared text renderer
- route controller input through the pause menu in MyPokemonLikeCart while suspending gameplay updates

## Testing
- `dotnet build MicroBoyHost.sln` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd400602c0832cb5a9695804407f72